### PR TITLE
fix GPL violation, PyQt5 is licensed under GPLv3, see https://www.riverbankcomputing.com/static/Docs/PyQt5/introduction.html#license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,21 +1,3 @@
-MIT License
+All software source code is licensed under GPLv3. (https://www.gnu.org/licenses/gpl-3.0.en.html)
 
-Copyright (c) [2023] [Maweilin]
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Everything else is licensed under CC-BY-SA-4.0. (https://creativecommons.org/licenses/by-sa/4.0)


### PR DESCRIPTION
大佬您好，您软件源码中用的PyQt5是GPLv3 license（见 <https://www.riverbankcomputing.com/static/Docs/PyQt5/introduction.html#license>），这是一种copyleft license，“衍生”的软件不能用更宽松的license，例如您现在使用的MIT license就是一种更宽松的permissive license，我提交的PR将软件源码license改为GPLv3。

我提交的PR还把其他（例如硬件CAD模型等）改为CC-BY-SA-4.0 license，因为creative commons license更适合非软件源码类。**注意CC-BY-SA也是copyleft license, 您可能更喜欢更宽松的CC-BY，您可以把其他非软件类改成CC-BY，这里我是有点私心的。**

我不是律师，没仔细看源码，也懒得修改太多，肯定有疏漏不严谨之处还望海涵。

非常感谢您开源这个项目。